### PR TITLE
Check index status in updateTableAndWait

### DIFF
--- a/index.js
+++ b/index.js
@@ -674,7 +674,10 @@ DynamoTable.prototype.updateTableAndWait = function(readCapacity, writeCapacity,
 
       self.describeTable(function(err, data) {
         if (err) return cb(err)
-        if (data.TableStatus !== 'ACTIVE') return setTimeout(checkTable, 1000, count)
+        if (data.TableStatus !== 'ACTIVE' || (data.GlobalSecondaryIndexes &&
+            !data.GlobalSecondaryIndexes.every(function (idx) {return idx.IndexStatus === 'ACTIVE'}))) {
+          return setTimeout(checkTable, 1000, count)
+        }
 
         // If the throughput has been provisoned then return
         if (readCapacity && data.ProvisionedThroughput.ReadCapacityUnits === readCapacity &&


### PR DESCRIPTION
- When only updating secondary indexes the `updateTableAndWait` function returns without checking if the secondary indexes are in an active state. When you immediately try another update it will cause a `ResourceInUse` exception.
