### PR TITLE
Do not use mapping.to for strings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function DynamoTable(name, options) {
 DynamoTable.prototype.mapAttrToDb = function(val, key, jsObj) {
   var mapping = this.mappings[key], numToStr = this._numToStr.bind(this, key)
   if (mapping) {
-    if (typeof mapping.to === 'function') return mapping.to(val, key, jsObj)
+    if (typeof mapping !== 'string' && typeof mapping.to === 'function') return mapping.to(val, key, jsObj)
     if (typeof val === 'undefined' || typeof val === 'function') return
     if (mapping === 'json') return {S: JSON.stringify(val)}
     if (val == null || val === '') return

--- a/test/fast.js
+++ b/test/fast.js
@@ -67,6 +67,17 @@ describe('mapAttrToDb', function() {
     table.mapAttrToDb(100, 'id').should.eql({S: '23'})
   })
 
+  it('should not use the mapping function for strings', function() {
+    String.prototype.to = function() { return 'failed'; };
+    var table = dynamoTable('name', {mappings: {id: 'S'} });
+
+    try {
+      table.mapAttrToDb('100', 'id').should.eql({S: '100'});
+    } finally {
+      delete String.prototype.to;
+    }
+  })
+
   it('should map explicit dynamodb types', function() {
     var table = dynamoTable('name', {mappings: {
       name: 'S',
@@ -1617,4 +1628,3 @@ describe('increment', function() {
     })
   })
 })
-


### PR DESCRIPTION
Some packages (jshint, as an example) inject a `to` method into
`String.prototype`. This causes dynamo-table to attempt to use that
method for mapping.

It doesn't appear that there's any reason for dynamo-table to attempt to
use the `to` method of a String, so just short circuit the check.
