### PR TITLE
Return LastEvaluatedKey from list requests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -721,7 +721,7 @@ DynamoTable.prototype._listRequest = function(operation, items, options, cb) {
       options.ExclusiveStartKey = data.LastEvaluatedKey
       return self._listRequest(operation, items, options, cb)
     }
-    cb(null, items)
+    cb(null, items, data.LastEvaluatedKey)
   })
 }
 


### PR DESCRIPTION
We're interested in using the last evaluated key to make subsequent requests, so we're returning it as an additional parameter to the callback. This should be ignored if the callback doesn't care about it, and lets us operate on it further.
